### PR TITLE
Añadidas traducciones de las pantomimas al español para Pathologic

### DIFF
--- a/pantomimas.md
+++ b/pantomimas.md
@@ -1,0 +1,217 @@
+**DÍA UNO**
+
+BACHILLER: ¿Entonces todo se trata de engaños para ti? ¿De dónde has venido?
+CAMBIANTE: No, no... Detesto el engaño. Pero si nosotros mismos hemos de sufrir
+           la decepción, nuestras manos ya no están atadas. ¿Dónde ESTAMOS?
+ARÚSPICE:  Bueno, hay una contracción muscular allí. Significa que ya estamos
+           dentro de él. ESTO debe ser uno de los ventrículos, justo aquí.
+CAMBIANTE: Qué lugar tan absurdo... ¡está abarrotado! ¿Entonces no es real por
+           ahora? No creo que haya comenzado aún.
+BACHILLER: ¿Importa de qué está hecho? Definitivamente está luchando.
+           Necesitamos realizar una sectio transversalis*. Cortar la pared. No
+           hay otra salida. ¿Qué más se puede hacer?
+CAMBIANTE: SÉ qué hacer. Aquellos que favorecen la lógica estricta y la acción
+           directa están destinados a equivocarse. Solo un milagro puede
+           liberarnos sin tener que destruir algo. Y yo puedo HACER milagros.
+           Déjame hacerlo.
+BACHILLER: ¿Quieres callarte? Eres un mentiroso y un ladrón. ¿Quién va a creerte
+           si sigues mintiéndote a ti mismo? La verdad es mi pastor. Pase lo que
+           pase, ENCONTRARÉ respuestas y se hará justicia. Realizaré la
+           operación. Medicum morbo adhibere**.
+ARÚSPICE:  No te pongas mandón conmigo, capa astuta... Actuarás con justicia,
+           pero tu justicia te cegará y será su perdición. Esto requiere la mano
+           delicada de un cirujano. Apartaos, ambos.
+CAMBIANTE: Tus manos delicadas están acostumbradas a matar, no a dar vida.
+           Inevitablemente causarás daño. Y el cerebrito no tiene consideración
+           por las víctimas en absoluto. Ninguno de vosotros conoce la compasión.
+BACHILLER: Sí, parece poco probable que nos llevemos bien, pero solo hay una
+           verdad.
+ARÚSPICE:  Cualquier elección es correcta mientras que sea voluntaria. Esa es la
+           verdad del asunto.
+CAMBIANTE: Solo el corazón te mostrará la elección correcta. Dejen de pensar en
+           vosotros mismos, piensen en el enfermo. Está sufriendo. No puedo
+           verlo aún, pero puedo sentirlo.
+CAMBIANTE: Esto ni siquiera es una trampa... es una tumba. Sub ipsum fumus
+           sumus***. No puedo decir que me conmueva.
+ARÚSPICE:  Ya veo. Estás lleno de odio. Lleno o no, está respirando. Puedo
+           curarlo. Puede ser curado, en lugar de asesinado.
+CAMBIANTE: ¿Quieres decir que no te convertirás en un asesino? ¡Pero lo harás!
+           Marca mis palabras, eso es exactamente lo que pasará. Pero yo puedo
+           evitarlo.
+BACHILLER: No... nunca nos llevaremos bien. Sugiero que sigamos nuestro camino.
+           Cuanto antes, mejor.
+CAMBIANTE: ¿Nos vamos entonces?
+ARÚSPICE:  Vamos. El reloj sigue avanzando...
+
+\* Sección transversal: Corte transversal obtenido al seccionar, realmente o
+mediante técnicas de imagen, el cuerpo o cualquier estructura corporal en un
+plano horizontal, intersectando el eje longitudinal en ángulo recto.
+
+\*\* La enfermedad se trata con medicina.
+
+\*\*\* Nublamos nuestro propio juicio.
+
+**DÍA DOS**
+
+- Hoy se identificó al asesino. Su naturaleza resultó ser completamente inesperada.
+- El enemigo ha sido encontrado y nombrado. Se llama la Peste de Arena. La peste
+contagiosa amenaza con arruinarlo todo aquí.
+- ¿Cómo se puede castigar a un asesino así? ¿Cómo se puede enfrentar a un villano
+así?
+- No se puede. Es imposible. Si se le enfrenta con un cuchillo, solo se cortará
+un cuerpo inocente.
+- Creo que... debería irme. No hay nada que hacer aquí de todos modos.
+- ¡DEBERÍAS irte! Vete entonces... a donde quieras. ¡Fuera!
+
+**DÍA TRES**
+
+- Los gobernantes tuvieron que aceptar que algo estaba mal. Los descubrimientos
+aterradores los convencieron. Uno de ellos logró frenar la disputa familiar.
+- Malas noticias... El gobernador abusará de su poder, y los demás no lo dejarán
+salirse con la suya. Nada ha cambiado.
+- La ciudad fue puesta en cuarentena. A partir de ahora, los distritos infectados
+estarán bloqueados y nadie podrá salir hasta que la situación se resuelva.
+- Bueno, no se resolverá. No encontrarán la solución.
+
+**DÍA CUATRO**
+
+- ¿Entonces?
+- Se mantiene alejada de los cadáveres. Desaparece de los cuerpos sin dejar
+rastro. Se ha establecido que se puede esperar a que pase, si uno es cuidadoso y
+discreto. El cristal mantendrá lo mejor como debe hacerlo.
+- ¿Qué significa?
+- Significa que tenemos una oportunidad de luchar. El agente infeccioso solo se
+adhiere a materia viva y es repelido por superficies muertas. Los que permanecen
+en interiores tienen más posibilidades de sobrevivir. Andar de aquí para allá
+significa la muerte. En resumen... podemos luchar.
+- Maldito egoísta... tienes tus propios intereses, ¿verdad? Siempre estás listo
+para pelear, solo necesitas un adversario. ¿Y qué hay de la gente?
+- Silencio, no te interpongas en su camino. Parece que tiene un plan.
+- Todo está mal... Esto no sirve de nada...
+
+**DÍA CINCO**
+
+- Uno de ellos está intentando luchar.
+- ¿Quién?
+- Este. Los otros dos intentarán frustrar sus esfuerzos.
+- Interesante... ¿Caerán en la trampa?
+- Me pregunto... Mira en qué han convertido el teatro.
+- Espero que sepan lo que están haciendo. Inevitablemente, mañana se derramará
+sangre.
+
+**DÍA SEIS**
+- Así que aquí estamos...
+- SE derramó tanta sangre.
+- ¿Derramada? ¿Te refieres a un accidente? ¿Algo con lo que no tuviste nada que
+ver?
+- Era necesario para que pudiéramos avanzar. Estamos en el camino hacia la
+victoria. ¿No estás de acuerdo?
+- Lo estamos. Ahora sabemos cómo luchar realmente contra la Peste de Arena. Los
+rumores falsos han sido desmentidos. No es un demonio. Solo son partículas
+diminutas que mueren rápidamente si no logran morder sangre caliente.
+- La gente teme la profecía de Katerina.
+- La gente solo teme el derramamiento de sangre cuando es SU sangre... y SU
+derramamiento.
+- La sangre no es más que un medio nutricional. Quien siembra sangre cosecha una
+rica cosecha.
+
+**DÍA SIETE**
+
+- Alguien pudo haber terminado empalado hoy. Tuve suerte de escapar de la
+ejecución. El Bachelor fue lo suficientemente noble para dejarme ir.
+- Increíble, la Peste de Arena no es una persona. Se ha demostrado. Pero, ¿quién
+es la fuente? No es la niña, eso está claro.
+- Puedes escapar de todos, incluso de la mano vengativa del inquisidor. Pero no
+puedes escapar de ti mismo. La Hermana Tierra está respirando sobre tu cuello.
+- ¿Qué haremos?
+- Siento que todo el mundo está en mi contra. No puedo quitarme este nudo. ¿Es
+inevitable la ejecución?
+- Tranquilízate, quejumbroso.
+- ¡Basta!
+- Puedes seguir siendo una herramienta... o convertirte en un rebelde. La
+elección es tuya. Los hombres luchan en nudos corredizos, pero las marionetas
+caminan libres.
+
+**DÍA OCHO**
+
+- Sé cómo funcionan los cuerpos celestes. Conozco la lógica de los números.
+- Sí, mamá.
+- Los cuerpos sólidos se hunden en el agua, es una ley. La vida se descompone en
+partículas y renace nuevamente, es una ley.
+- ¿Ves ahora cuántos misterios guarda la tierra? Cuanto más aterrador el
+misterio, más profundo yace, y menos pozos pueden alcanzarlo.
+- Puedes engañar a cualquiera... menos a mí, el emisario de los Poderes Fácticos.
+Sé cómo fue construido este mundo, sé cómo funciona su vida. Conozco las leyes
+bajo las cuales opera. Se supone que todo es muy simple y proporcional.
+- ¡Cierto! ¡Cierto, mamá!
+- Así se supone que debe ser.
+- ¡Cierto! ¡Cierto, mamá! Así debe ser.
+- Que así sea, no es el fin del mundo, solo una epidemia. Se ha salido de
+proporción. La ley prevalecerá. Restauraré el equilibrio. No todo está perdido.
+Sé dónde está la raíz de este mal.
+- Hmmm...
+
+**DÍA NUEVE**  
+Esta obra solo puede verse si el Bachelor no entró en el Matadero el día
+anterior. Entrar y terminar la misión "Putrefacción Subterránea" salta el tiempo
+a las 2 p.m., mucho después de que la función haya terminado.
+
+- ¿Ves ahora cuántos misterios guarda la tierra? Cuanto más aterrador el
+misterio, más profundo yace, y menos pozos pueden alcanzarlo.
+- Las entrañas del Matadero fueron volteadas al revés. Allí... hay... bestias...
+allí...
+- Está lleno de raíces y tierra. Las puertas subterráneas se abren fácilmente,
+pero solo puedes pasar si hay una tumba detrás. ¿Entiendes lo que digo?
+- No hay nada que perder de todos modos. Los soldados estarán aquí mañana.
+¡Arriesguémonos!
+- Eres libre de ir a cualquier lado. A la derecha... a la izquierda... hacia
+arriba... pero incluso un poco hacia abajo. Estás invitado a asegurarte de que no
+haya trucos.
+- ¿A quién le importa? ¡Es todo lo mismo al final!
+
+**DÍA DIEZ**
+
+- Mis órdenes eran destruir cada edificio en esta ciudad, y luego disparar a
+todos los que sobrevivan al bombardeo. El ejército solo viene cuando ya no queda
+nada por arreglar. Sin embargo, estoy dispuesto a romper ese hábito. Sé que las
+personas que pueden cambiar el curso de la catástrofe han estado trabajando aquí
+por un tiempo. Solo destruiremos lo que señale un sanador que pueda argumentar en
+favor de tomar esa acción.
+- ¿Qué tal si no disparamos nada en absoluto?
+- Si no disparamos a nada, las consecuencias serán devastadoras. Querías libertad
+de elección... así que elige. Un bombardeo masivo o un solo ataque preciso. De
+una forma u otra, pondremos fin a este circo.
+
+**DÍA ONCE**
+
+- La ley de la gravedad es trágicamente incompatible con atrapar sueños. Las
+ilusiones deben dejarse ir a tiempo.
+- Hay una forma complicada de salvar la torre especular, pero habrá bajas. ¿Qué
+dices?
+- La ley exige que guardemos silencio... como si no hubiera nada que salvar,
+excepto esta ridícula torre.
+- Hay otra forma complicada. Permite salvar la torre de los hombres, pero TAMBIÉN
+requiere un sacrificio. ¿Qué dices?
+- La ley es imparcial. La elección es tuya.
+- ¿Hay una forma alternativa de subvertir tu ley ridículamente injusta?
+- Solo hacemos nuestro trabajo, ¿por qué tanto alboroto? Tienes tiempo, vive un
+poco más.
+
+**DÍA DOCE**
+
+- Hagas lo que hagas, tendrás que sacrificar algo.
+- La destrucción es inevitable, no hay forma milagrosa de salir.
+- Hm, así que ese es su proceso de pensamiento, ¿ves? Nunca hubo nada que esperar
+desde el principio. Cada uno de ellos simplemente debe cumplir su propósito. Al
+menos veremos cuál funciona mejor...
+- Cada uno de ellos quiere salvar lo que les es querido. Quizás, podrían...
+¿llevarse bien?
+- Fuera de cuestión. La sala de reuniones es estrecha, con el general sentado en
+un lado de la mesa y el inquisidor en el otro. Solo uno de ellos decidirá. Los
+demás morirán...
+
+**FINAL VERDADERO**
+
+- ¡Lo lograste! Fue una elección libre. Reconocemos la victoria del jugador.
+- Es realmente milagroso, la salida está clara. No debería haber sucedido. El
+milagro debe ser real.


### PR DESCRIPTION
Estaba probando la traducción que hiciste, pero vi que las secciones en el teatro (las pantomimas) no estan al español ya que son segmentos sin ninguna clase de subtitulos, por lo que pensé que sería bueno introducir un archivo donde poder leer la traducción a estos segmentos, mi traducción es algo rapida pero seguro puedes revisar y corregirla, puedes encontrar el texto original en [Pathologic Wiki](https://pathologic.fandom.com/wiki/Pantomimes/Text), gracias por tu traducción.